### PR TITLE
Draw rect fill

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ widget = ["dep:plotters"]
 anyhow = "1.0.75"
 crossterm = "0.27.0"
 flexi_logger = "0.27.2"
+indoc = "2.0.4"
 itertools = "0.12.1"
 num-traits = "0.2.17"
 plotters = "0.3.5"

--- a/examples/boilerplate.rs
+++ b/examples/boilerplate.rs
@@ -15,6 +15,10 @@ use ratatui::layout::Direction;
 use ratatui::prelude::{Constraint, CrosstermBackend, Layout};
 use ratatui::Terminal;
 
+// cargo test requires this file to have a `main()`
+#[allow(dead_code)]
+fn main() {}
+
 pub fn main_boilerplate(
     draw_fns: &[fn(DrawingArea<RatatuiBackend, coord::Shift>) -> AreaResult],
 ) -> anyhow::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod widget;
 #[cfg(feature = "widget")]
 pub use widget::*;
 
-pub const CHAR_PIXEL_SIZE: u32 = 4;
+pub const CHAR_PIXEL_DIMS: (u32, u32) = (2, 4);
 
 pub struct RatatuiBackend<'a, 'b> {
     pub canvas: &'a mut canvas::Context<'b>,
@@ -41,7 +41,7 @@ impl<'a, 'b> DrawingBackend for RatatuiBackend<'a, 'b> {
         mut coord: BackendCoord,
     ) -> Result {
         let width = text.chars().count();
-        coord.0 -= (width as u32 * CHAR_PIXEL_SIZE / 2) as i32;
+        coord.0 -= (width as u32 * CHAR_PIXEL_DIMS.0 / 2) as i32;
 
         let (x, y) = backend_to_canvas_coords(coord, self.size);
         self.canvas.print(x, y, text::Line::styled(text.to_string(), convert_style(style)));
@@ -103,12 +103,12 @@ impl<'a, 'b> DrawingBackend for RatatuiBackend<'a, 'b> {
         text: &str,
         _style: &TStyle,
     ) -> std::result::Result<(u32, u32), DrawingErrorKind<Self::ErrorType>> {
-        Ok((text.chars().count() as u32 * CHAR_PIXEL_SIZE, CHAR_PIXEL_SIZE))
+        Ok((text.chars().count() as u32 * CHAR_PIXEL_DIMS.0, CHAR_PIXEL_DIMS.1))
     }
 }
 
 fn rect_to_size(rect: layout::Rect) -> (u32, u32) {
-    (u32::from(rect.width) * CHAR_PIXEL_SIZE, u32::from(rect.height) * CHAR_PIXEL_SIZE)
+    (u32::from(rect.width) * CHAR_PIXEL_DIMS.0, u32::from(rect.height) * CHAR_PIXEL_DIMS.1)
 }
 
 fn backend_to_canvas_coords((x, y): BackendCoord, rect: layout::Rect) -> (f64, f64) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,18 +83,34 @@ impl<'a, 'b> DrawingBackend for RatatuiBackend<'a, 'b> {
         coord1: BackendCoord,
         coord2: BackendCoord,
         style: &S,
-        _fill: bool,
+        fill: bool,
     ) -> std::result::Result<(), DrawingErrorKind<Self::ErrorType>> {
-        let (x1, y1) = backend_to_canvas_coords(coord1, self.size);
-        let (x2, y2) = backend_to_canvas_coords(coord2, self.size);
+        let color = convert_color(style.color());
 
-        self.canvas.draw(&canvas::Rectangle {
-            x:      x1.min(x2),
-            y:      y1.min(y2),
-            width:  (x2 - x1).abs(),
-            height: (y2 - y1).abs(),
-            color:  convert_color(style.color()),
-        });
+        let (start, stop) = (
+            (coord1.0.min(coord2.0), coord1.1.min(coord2.1)),
+            (coord1.0.max(coord2.0), coord1.1.max(coord2.1)),
+        );
+
+        if fill {
+            for x in start.0..=stop.0 {
+                let (x1, y1) = backend_to_canvas_coords((x, start.1), self.size);
+                let (x2, y2) = backend_to_canvas_coords((x, stop.1), self.size);
+
+                self.canvas.draw(&canvas::Line::new(x1, y1, x2, y2, color));
+            }
+        } else {
+            let (x1, y1) = backend_to_canvas_coords(start, self.size);
+            let (x2, y2) = backend_to_canvas_coords(stop, self.size);
+
+            self.canvas.draw(&canvas::Rectangle {
+                x: x1,
+                y: y1,
+                width: x2 - x1,
+                height: y2 - y1,
+                color:  convert_color(style.color()),
+            });
+        };
         Ok(())
     }
 


### PR DESCRIPTION
Here's a newer version of my previous PR with just a fill implementation added for `draw_rect`, i.e not `for draw_circle `but it does include proper render buffer based tests for `draw_rect`, and fixes a couple of other issues too.

I've left the older PR up for reference for now, but will delete it soon.