### PR TITLE
Update to Ratatui v0.29 and Crossterm v0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plotters-ratatui-backend"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["SOFe <sofe2038@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ description = "Ratatui widget to draw a plotters chart"
 
 [dependencies]
 plotters-backend = "0.3.5"
-ratatui = "0.26.0"
+ratatui = "0.29.0"
 thiserror = "1.0.50"
 plotters = {version = "0.3.5", optional = true, default-features = false}
 log = "0.4.20"
@@ -21,7 +21,7 @@ widget = ["dep:plotters"]
 
 [dev-dependencies]
 anyhow = "1.0.75"
-crossterm = "0.27.0"
+crossterm = "0.28.0"
 flexi_logger = "0.27.2"
 itertools = "0.12.1"
 num-traits = "0.2.17"
@@ -29,4 +29,3 @@ plotters = "0.3.5"
 rand = "0.8.5"
 rand_distr = "0.4.3"
 rand_xorshift = "0.3.0"
-

--- a/examples/boilerplate.rs
+++ b/examples/boilerplate.rs
@@ -35,7 +35,7 @@ pub fn main_boilerplate(
                 Direction::Horizontal,
                 std::iter::repeat(Constraint::Ratio(1, draw_fns.len() as u32)).take(draw_fns.len()),
             )
-            .split(frame.size());
+            .split(frame.area());
             for (&rect, &draw_fn) in iter::zip(&*rects, draw_fns) {
                 frame.render_widget(widget_fn(draw_fn), rect);
             }


### PR DESCRIPTION
Update to the current versions of Ratatui (and secondarily, since it's a dev dependency, Crossterm).  This is necessary in order to be able to use `plotters-ratatui-backend` in applications that use the current version (0.29) of Ratatui.

This is a breaking change since it is a major version bump of the dependencies and so it is incompatible with crates that use any other Ratatui version other than 0.29.x, so I included a crate version bump to 0.2.0.